### PR TITLE
Let dashboard take up whole screen

### DIFF
--- a/assets/strava.css
+++ b/assets/strava.css
@@ -29,6 +29,7 @@ b {
 
 .container {
     margin: 10vh;
+    width: auto; /* override bootstrap to avoid pixel sizing */
 }
 
 p {


### PR DESCRIPTION
Just overriding bootstrap's assumed 940px width so we can be more fluid.